### PR TITLE
PE-70 Add explanation for Jira key in PR title

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,6 +195,7 @@ Valid sample PR titles:
   ‣ 'INTG-332 Add logging to external api'
 
 <p><strong>💡 TIP:</strong> If you're certain the title is correct, try closing and reopening the pull request as a work-around. Sometimes the request data to the action gets cached.</p>
+<p><strong>🤔 Why?</strong> So that it will automatically show up in the Development section of the Jira issue! 🚀</p>
   `;
 };
 


### PR DESCRIPTION
🤝 Please feel free to add anyone that I've missed

Upon first glance, requiring the Jira key in a Pull Request title seems less important than the branch name and commits (those help drive our CI/CD dashboard). However, we've learned that including the Jira key in the PR title is the glue that links the pull request to the Development section in a Jira issue:

![Screen Shot 2023-02-03 at 8 54 00 AM](https://user-images.githubusercontent.com/4965259/216634204-b06b6241-d00a-4731-ac90-11ae8b2de581.png)

Adding the explanation in the PR comment when this check fails can help the author understand why it is required.